### PR TITLE
[saithriftv2] Add the missing API to saithriftv2 required for syncd

### DIFF
--- a/meta/sai_rpc_frontend.cpp
+++ b/meta/sai_rpc_frontend.cpp
@@ -930,6 +930,16 @@ int start_p4_sai_thrift_rpc_server(char *port) {
 }
 
 /**
+ * @brief Start Thrift RPC server Wrapper
+ */
+int start_sai_thrift_rpc_server(int port)
+{
+    static char port_str[10];
+    snprintf(port_str, sizeof(port_str), "%d", port);
+    return start_p4_sai_thrift_rpc_server(port_str);
+}
+
+/**
  * @brief Stop Thrift RPC server
  */
 int stop_p4_sai_thrift_rpc_server(void) {

--- a/test/saithriftv2/src/saiserver.cpp
+++ b/test/saithriftv2/src/saiserver.cpp
@@ -266,13 +266,6 @@ void handleInitScript(const std::string& initScript)
     system(initScript.c_str());
 }
 
-int start_sai_thrift_rpc_server(int port)
-{
-    static char port_str[10];
-    snprintf(port_str, sizeof(port_str), "%d", port);
-    return start_p4_sai_thrift_rpc_server(port_str);
-}
-
 int
 main(int argc, char* argv[])
 {

--- a/test/saithriftv2/src/switch_sai_rpc_server.h
+++ b/test/saithriftv2/src/switch_sai_rpc_server.h
@@ -1,3 +1,4 @@
 extern "C" {
 int start_p4_sai_thrift_rpc_server(char *port);
+int start_sai_thrift_rpc_server(int port);
 }


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

saithriftv1 offers `start_sai_thrift_rpc_server` API to start the saithrift server and syncd is currently using that API https://github.com/Azure/sonic-sairedis/blob/master/syncd/syncd_main.cpp#L60

But this API is missing from the for saithriftv2.

Made the relevant changes to provide a similar API for saithriftv2 library

The `start_sai_thrift_rpc_server` API currently resides in saiserver.cpp which is not included in librpcserver.a and is not available for the users of the static library. Thus moved the function definition into sai_rpc_frontend.cpp for including it in the static library.  

```
syncd_main.cpp: In function 'int syncd_main(int, char**)':
syncd_main.cpp:60:9: error: 'start_sai_thrift_rpc_server' was not declared in this scope; did you mean 'start_p4_sai_thrift_rpc_server'?
   60 |         start_sai_thrift_rpc_server(SWITCH_SAI_THRIFT_RPC_SERVER_PORT);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |         start_p4_sai_thrift_rpc_server
Error 1
make[3]: Leaving directory '/sonic/src/sonic-sairedis/syncd'
Error 1
make[2]: Leaving directory '/sonic/src/sonic-sairedis'
dh_auto_install: error: make -j1 install DESTDIR=/sonic/src/sonic-sairedis/debian/tmp AM_UPDATE_INFO_DIR=no returned exit code 2
Error 25
make[1]: Leaving directory '/sonic/src/sonic-sairedis'
dpkg-buildpackage: error: fakeroot debian/rules binary-syncd-rpc subprocess returned exit status 2

```
